### PR TITLE
[bugfix] post get api bugfix

### DIFF
--- a/src/router/postApi.ts
+++ b/src/router/postApi.ts
@@ -83,8 +83,11 @@ router.get('/@:username/:url_slug', (req, response) => {
     ON public."BLOG_USERS".user_id = public."BLOG_POSTS".fk_user_id
     WHERE (velog_name='${userName}' AND url_slug='${slug}')`,
     (err, result) => {
-      const users = result.rows;
-      response.status(200).json(users);
+      if (result.rows.length === 0) {
+        return response.status(404).json({ err: 'Post Not Found' });
+      }
+      const post = result.rows[0];
+      return response.status(200).json(post);
     }
   );
 });


### PR DESCRIPTION
- get post url response array에서 단일 객체로 반환하도록 변경
- 404 에러 추가

- - -
- problem: returned value is array, but the value must be one post
- add 404 error case when getting a post fails
- modification: result.rows -> result.rows[0]