### PR TITLE
[feat] post cache setting of response header

### DIFF
--- a/src/router/postApi.ts
+++ b/src/router/postApi.ts
@@ -87,6 +87,11 @@ router.get('/@:username/:url_slug', (req, response) => {
         return response.status(404).json({ err: 'Post Not Found' });
       }
       const post = result.rows[0];
+      response.setHeader('Cache-Control', 'private, no-cache');
+      if (req.headers['if-modified-since'] === new Date(post.released_at).toUTCString()) {
+        return response.status(304).send();
+      }
+      response.setHeader('Last-Modified', new Date(post.released_at).toUTCString());
       return response.status(200).json(post);
     }
   );


### PR DESCRIPTION
- set cache-control header
-- private: caching in client browser
-- no-cache: always checking revalidation
- insert Last-modified feild: post released date
-- if the date doen't change, return 304(client uses cached data)
-- else 200 OK