### PR TITLE
[feat] post like api

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import express from 'express';
 import userApi from './router/userApi';
 import postApi from './router/postApi';
+import postLikeApi from './router/postLikeApi';
 import loginApi from './router/loginApi';
 import imgApi from './router/imgApi';
 import cors from 'cors';
@@ -27,9 +28,9 @@ server.use(express.urlencoded({ extended: true }));
 server.use(cors()); //모든 cross-origin 요청에 대해 응답
 server.use(userApi);
 server.use(postApi);
+server.use(postLikeApi);
 server.use(loginApi);
 server.use(imgApi);
-
 server
   .listen(server.get('port'), () => {
     console.log(`${server.get('port')} server is Running`);

--- a/src/router/postLikeApi.ts
+++ b/src/router/postLikeApi.ts
@@ -1,0 +1,84 @@
+import express from 'express';
+import dbConn from '../db/dbConn';
+
+const router = express.Router();
+
+router.get('/readingList/:userName/liked/', async (req, response) => {
+  const { userName } = req.params;
+  const result = await dbConn.query(
+    `SELECT * FROM public."POST_LIKES" WHERE fk_user_id='${userName}' ORDER BY updated_at DESC;`
+  );
+
+  const likedPost = result.rows;
+  return response.status(200).json(likedPost);
+});
+
+router.get('/readingList/:userName/liked/:loadPostCount', async (req, response) => {
+  const { userName, loadPostCount } = req.params;
+  const result = await dbConn.query(
+    `SELECT * FROM public."POST_LIKES" WHERE fk_user_id='${userName}' ORDER BY updated_at DESC LIMIT 16 OFFSET ${
+      +loadPostCount * 15
+    };`
+  );
+
+  const likedPost = result.rows;
+  return response.status(200).json(likedPost);
+});
+
+router.get('/:userName/liked/:postId', (req, response) => {
+  const { userName, postId } = req.params;
+  dbConn.query(
+    `SELECT id FROM public."POST_LIKES" WHERE fk_user_id='${userName}' AND fk_post_id='${postId}'`,
+    (err, result) => {
+      console.log(result);
+      const likedPost = result.rows;
+      response.status(200).json(likedPost);
+    }
+  );
+});
+
+router.post('/:userName/like/:postId', async (req, response) => {
+  const { userName, postId } = req.params;
+  const postResult = await dbConn.query(`SELECT id FROM public."BLOG_POSTS" WHERE id='${postId}'`);
+
+  if (postResult.rowCount === 0) {
+    return response.status(404).json({ err: 'Post Not Found' });
+  }
+
+  const alreadyLiked = await dbConn.query(
+    `SELECT id FROM public."POST_LIKES" WHERE fk_user_id='${userName}' AND fk_post_id='${postId}'`
+  );
+
+  if (alreadyLiked.rowCount !== 0) {
+    return response.status(304).json(alreadyLiked);
+  }
+
+  const insertLiked = await dbConn.query(
+    `INSERT INTO public."POST_LIKES" (created_at, updated_at, fk_post_id, fk_user_id) VALUES (current_timestamp, current_timestamp, '${postId}', '${userName}'); `
+  );
+
+  return response.status(201).json(`${userName} liked ${postId}`);
+});
+
+router.post('/:userName/unlike/:postId', async (req, response) => {
+  const { userName, postId } = req.params;
+  const postResult = await dbConn.query(`SELECT id FROM public."BLOG_POSTS" WHERE id='${postId}'`);
+  if (postResult.rowCount === 0) {
+    return response.status(404).json({ err: 'Post Not Found' });
+  }
+
+  const alreadyLiked = await dbConn.query(
+    `SELECT id FROM public."POST_LIKES" WHERE fk_user_id='${userName}' AND fk_post_id='${postId}'`
+  );
+  if (!alreadyLiked.rowCount) {
+    return response.status(204).json({ err: 'Post Not Liked' });
+  }
+
+  const unliked = await dbConn.query(
+    `DELETE FROM public."POST_LIKES" WHERE fk_user_id='${userName}' AND fk_post_id='${postId}'`
+  );
+
+  return response.status(202).json(`${userName} unliked ${postId}`);
+});
+
+export default router;

--- a/src/router/postLikeApi.ts
+++ b/src/router/postLikeApi.ts
@@ -9,6 +9,10 @@ router.get('/:userName/readingList/liked/', async (req, response) => {
     `SELECT * FROM public."POST_LIKES" WHERE fk_user_id='${userName}' ORDER BY updated_at DESC;`
   );
 
+  if (!result) {
+    return response.status(200).json({});
+  }
+
   const likedPost = result.rows;
   return response.status(200).json(likedPost);
 });
@@ -21,6 +25,10 @@ router.get('/:userName/readingList/liked/:loadPostCount', async (req, response) 
     };`
   );
 
+  if (!result) {
+    return response.status(200).json({});
+  }
+
   const likedPost = result.rows;
   return response.status(200).json(likedPost);
 });
@@ -30,7 +38,9 @@ router.get('/:userName/liked/:postId', (req, response) => {
   dbConn.query(
     `SELECT id FROM public."POST_LIKES" WHERE fk_user_id='${userName}' AND fk_post_id='${postId}'`,
     (err, result) => {
-      console.log(result);
+      if (!result) {
+        return response.status(200).json({});
+      }
       const likedPost = result.rows;
       response.status(200).json(likedPost);
     }

--- a/src/router/postLikeApi.ts
+++ b/src/router/postLikeApi.ts
@@ -3,7 +3,7 @@ import dbConn from '../db/dbConn';
 
 const router = express.Router();
 
-router.get('/readingList/:userName/liked/', async (req, response) => {
+router.get('/:userName/readingList/liked/', async (req, response) => {
   const { userName } = req.params;
   const result = await dbConn.query(
     `SELECT * FROM public."POST_LIKES" WHERE fk_user_id='${userName}' ORDER BY updated_at DESC;`
@@ -13,7 +13,7 @@ router.get('/readingList/:userName/liked/', async (req, response) => {
   return response.status(200).json(likedPost);
 });
 
-router.get('/readingList/:userName/liked/:loadPostCount', async (req, response) => {
+router.get('/:userName/readingList/liked/:loadPostCount', async (req, response) => {
   const { userName, loadPostCount } = req.params;
   const result = await dbConn.query(
     `SELECT * FROM public."POST_LIKES" as p JOIN public."BLOG_POSTS" as b ON p.fk_post_id = b.id WHERE p.fk_user_id='${userName}' ORDER BY updated_at DESC LIMIT 16 OFFSET ${

--- a/src/test_server.ts
+++ b/src/test_server.ts
@@ -2,6 +2,7 @@
 import express from 'express';
 import userApi from './router/userApi';
 import postApi from './router/postApi';
+import postLikeApi from './router/postLikeApi';
 import loginApi from './router/loginApi';
 import cors from 'cors';
 
@@ -25,6 +26,7 @@ server.use(express.urlencoded({ extended: true }));
 server.use(cors()); //모든 cross-origin 요청에 대해 응답
 server.use(userApi);
 server.use(postApi);
+server.use(postLikeApi);
 server.use(loginApi);
 
 export default server;


### PR DESCRIPTION
- like 관련 reading list api 추가
  - reading list의 like 기준
    - count는 기존 main reading list 방식 따름
  - specific post에 대한 현재 user가 좋아요했는지에 대한 값 api 추가
    - 특정 post를 누를 때 사용 예정
- like 변경 api 추가
  - like 누를 때 like table에 insert
  - like 취소할 때 like table에서 delete